### PR TITLE
Set syntax for files without extensions

### DIFF
--- a/files/vimrc
+++ b/files/vimrc
@@ -78,6 +78,7 @@ au BufRead,BufNewFile Dockerfile* set syntax=dockerfile
 au BufRead,BufNewFile .eslintrc set syntax=json
 au BufRead,BufNewFile *.tsx set syntax=typescript
 au BufRead,BufNewFile *.erdconfig set syntax=yaml
+au BufNewFile,BufRead * if &syntax == '' | set syntax=sh | endif
 autocmd FileType vue noremap <buffer> <C-f> :%!vue-formatter<CR>
 set hlsearch
 if has("autocmd")


### PR DESCRIPTION
vimrc updates

```
+ au BufNewFile,BufRead * if &syntax == '' | set syntax=sh | endif
```