### PR TITLE
*.axlsx file highlighting as Ruby files

### DIFF
--- a/files/vimrc
+++ b/files/vimrc
@@ -66,6 +66,7 @@ let g:neocomplete#enable_at_startup = 2
 au BufRead,BufNewFile *.thor set syntax=ruby
 au BufRead,BufNewFile *.simplecov set syntax=ruby
 au BufRead,BufNewFile *.gemfile set syntax=ruby
+au BufRead,BufNewFile *.axlsx set syntax=ruby
 au BufRead,BufNewFile *.es6 set filetype=javascript
 au BufRead,BufNewFile *.vue set filetype=javascript
 au BufRead,BufNewFile *.vue set syntax=javascript


### PR DESCRIPTION
The very popular gem `axlsx` supports `*.axlsx` files as views.

I've added highlighting for this file extension.