### PR TITLE
Update vimrc to set F6 button to execute :%d

### DIFF
--- a/files/init.vim
+++ b/files/init.vim
@@ -51,8 +51,8 @@ imap <F4> <Esc>:wq<CR>
 map <F4> <Esc>:wq<CR>
 imap <silent> <F5> <Esc>:noh<CR>
 map <F5> <Esc>:noh<CR>
-imap <F6> <Esc>:%s/:\([^ ]*\)\(\s*\)=>/\1:/g<CR>
-map <F6> <Esc>:%s/:\([^ ]*\)\(\s*\)=>/\1:/g<CR>
+imap <F6> <Esc>:%d<CR>
+map <F6> <Esc>:%d<CR>
 imap <F7> <Esc>:FZF<CR>
 map <F7> <Esc>:FZF<CR>
 imap <F8> <Esc>:new<CR>:FZF<CR>

--- a/files/vimrc
+++ b/files/vimrc
@@ -57,8 +57,8 @@ imap <F4> <Esc>:wq<CR>
 map <F4> <Esc>:wq<CR>
 imap <silent> <F5> <Esc>:noh<CR>
 map <F5> <Esc>:noh<CR>
-imap <F6> <Esc>:%s/:\([^ ]*\)\(\s*\)=>/\1:/g<CR>
-map <F6> <Esc>:%s/:\([^ ]*\)\(\s*\)=>/\1:/g<CR>
+imap <F6> <Esc>:%d<CR>
+map <F6> <Esc>:%d<CR>
 imap <F7> <Esc>:FZF<CR>
 map <F7> <Esc>:FZF<CR>
 imap <F8> <Esc>:new<CR>:FZF<CR>


### PR DESCRIPTION
Update vimrc and init.vim to set F6 button to execute `:%d<CR>` command

* Modify `files/vimrc` to set the F6 button to execute the command `:%d<CR>` and remove the existing F6 button mapping command `:%s/:\([^ ]*\)\(\s*\)=>/\1:/g<CR>`.
* Modify `files/init.vim` to set the F6 button to execute the command `:%d<CR>` and remove the existing F6 button mapping command `:%s/:\([^ ]*\)\(\s*\)=>/\1:/g<CR>`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kalashnikovisme/dotfiles/pull/33?shareId=0b2da23f-8555-40b8-aafa-c77d92ae6aa8).