### PR TITLE
Add Arch Linux installation mode and generic package management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,14 @@ install_environment:
 	ansible-playbook devices/bluetooth.yml -i local -vv
 	ansible-playbook devices/lefthook.yml -i local -vv
 	./sec/1password_cli.sh
-install_ansible:
-	sudo apt install -y software-properties-common
-	sudo apt install -y ansible
-	ansible-galaxy collection install community.general
+install_ansible_ubuntu:
+        sudo apt install -y software-properties-common
+        sudo apt install -y ansible
+        ansible-galaxy collection install community.general
+
+install_ansible_arch:
+        sudo pacman -Syu --noconfirm ansible
+        ansible-galaxy collection install community.general
 update_neovim:
 	ansible-playbook devtools/neovim.yml -i local -vv
 update_bash:

--- a/Readme.md
+++ b/Readme.md
@@ -2,13 +2,21 @@
 
 Just run
 
+### Ubuntu
+
 ```
-sudo apt-get install unzip && wget -O main.zip https://github.com/kalashnikovisme/dotfiles/archive/refs/heads/main.zip && unzip main.zip -d dotfiles && cd dotfiles/dotfiles-main && ./main.sh && cd ~ && sudo rm -rf main.zip dotfiles
+sudo apt-get install unzip && wget -O main.zip https://github.com/kalashnikovisme/dotfiles/archive/refs/heads/main.zip && unzip main.zip -d dotfiles && cd dotfiles/dotfiles-main && ./main.sh ubuntu && cd ~ && sudo rm -rf main.zip dotfiles
+```
+
+### Arch Linux
+
+```
+sudo pacman -Sy --noconfirm unzip wget && wget -O main.zip https://github.com/kalashnikovisme/dotfiles/archive/refs/heads/main.zip && unzip main.zip -d dotfiles && cd dotfiles/dotfiles-main && ./main.sh arch && cd ~ && sudo rm -rf main.zip dotfiles
 ```
 
 ## What is it?
 
-It's script to setup my own configuration for Ubuntu 22.04 (my current OS)
+It's script to setup my own configuration for Ubuntu or Arch Linux
 
 It installs Ansible and use Ansible playbook to install other applications
 

--- a/content/obs.yml
+++ b/content/obs.yml
@@ -1,16 +1,31 @@
 - hosts: all
   become_user: root
   tasks:
-    - name: Install obs && virtual camera
+    - name: Install obs virtual camera (Debian)
       become: true
-      apt:
-        pkg:
+      package:
+        name:
           - v4l2loopback-dkms
-    - name: Update repository for OBS
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Update repository for OBS (Debian)
       shell: sudo add-apt-repository ppa:obsproject/obs-studio
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Refresh packages (Debian)
       shell: sudo apt -y update
-    - name: Install obs
-      apt:
-        pkg:
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Install obs (Debian)
+      package:
+        name:
           - obs-studio
       become: true
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Install obs (Arch)
+      package:
+        name:
+          - obs-studio
+      become: true
+      when: ansible_pkg_mgr == 'pacman'

--- a/devices/bluetooth.yml
+++ b/devices/bluetooth.yml
@@ -1,10 +1,10 @@
 - hosts: all
   become_user: root
   tasks:
-    - name: Install blueman
+    - name: Install bluetooth packages
       become: true
-      apt:
-        pkg:
+      package:
+        name:
           - blueman
           - bluez
           - bluez-obexd

--- a/devtools/docker.yml
+++ b/devtools/docker.yml
@@ -3,26 +3,36 @@
     docker_compose_version: "2.19.1"
   become_user: root
   tasks: 
-    - name: "Docker: Update the apt package index and install packages to allow apt to use a repository over HTTPS"
-      apt:
-        pkg:
+    - name: "Docker: Install prerequisites (Debian)"
+      package:
+        name:
           - ca-certificates
           - gnupg
           - curl
       become: true
+      when: ansible_pkg_mgr == 'apt'
     - name: "Docker: prepare installation"
       command: sh ./docker/prepare_installation.sh
       become: true
-    - name: "Docker: install"
-      apt:
-        pkg:
-          # - docker.io
+      when: ansible_pkg_mgr == 'apt'
+    - name: "Docker: install (Debian)"
+      package:
+        name:
           - docker-ce
           - docker-ce-cli
           - containerd.io
           - docker-buildx-plugin
           - docker-compose-plugin
       become: true
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: "Docker: install (Arch)"
+      package:
+        name:
+          - docker
+          - docker-compose
+      become: true
+      when: ansible_pkg_mgr == 'pacman'
     - name: Post-install docker actions. Create docker group
       group:
         name: docker

--- a/devtools/git.yml
+++ b/devtools/git.yml
@@ -6,9 +6,9 @@
   tasks:
     - name: Install git
       become: true
-      apt:
-        pkg:
-          - git-core
+      package:
+        name:
+          - git
     - command: git config --global user.email "{{ email }}"
     - command: git config --global user.name "{{ name }}"
     - command: git config --global core.excludesfile ~/.gitignore
@@ -16,8 +16,8 @@
     - command: git config --global init.defaultBranch "main"
     - name: Install git-flow
       become: true
-      apt:
-        pkg:
+      package:
+        name:
           - git-flow
     - copy:
         src: "../files/gitignore"

--- a/devtools/neovim.yml
+++ b/devtools/neovim.yml
@@ -3,7 +3,7 @@
   tasks:
     - name: Install Neovim
       become: yes
-      apt:
+      package:
         name: neovim
         state: present
 

--- a/devtools/vim.yml
+++ b/devtools/vim.yml
@@ -7,8 +7,8 @@
         dest: ~/.vimrc
     - name: Install Vim and needed stuff
       become: true
-      apt:
-        pkg:
+      package:
+        name:
           - vim
           - vim-nox
           - vim-gtk
@@ -48,13 +48,29 @@
     - copy:
         src: "../files/vimrc"
         dest: "~/.vimrc"
-    - name: Install deoplete
-      apt:
-        pkg:
+    - name: Install deoplete (Debian)
+      package:
+        name:
           - python3-pip
-    - name: Install pynvim and msgpack via apt
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Install deoplete (Arch)
+      package:
+        name:
+          - python-pip
+      when: ansible_pkg_mgr == 'pacman'
+    - name: Install pynvim and msgpack (Debian)
       become: true
-      apt:
-        pkg:
+      package:
+        name:
           - python3-pynvim
           - python3-msgpack
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Install pynvim and msgpack (Arch)
+      become: true
+      package:
+        name:
+          - python-pynvim
+          - python-msgpack
+      when: ansible_pkg_mgr == 'pacman'

--- a/languages/rust.yml
+++ b/languages/rust.yml
@@ -2,8 +2,8 @@
   tasks:
     - name: "Rust: install clang"
       become: true
-      apt:
-        pkg:
+      package:
+        name:
           - clang
 
     - name: "Rust: download rustup"

--- a/main.sh
+++ b/main.sh
@@ -1,11 +1,42 @@
-echo 'Upgrade apt'
-sudo apt-get -y upgrade
-echo 'apt-get update'
-sudo apt-get -y update
-echo 'Install make'
-sudo apt-get install make
-echo 'Install ansible'
-make install_ansible
+#!/usr/bin/env bash
+
+set -e
+
+OS="$1"
+
+if [ -z "$OS" ]; then
+  if [ -f /etc/arch-release ]; then
+    OS="arch"
+  elif [ -f /etc/debian_version ]; then
+    OS="ubuntu"
+  fi
+fi
+
+case "$OS" in
+  arch)
+    echo 'Upgrade pacman'
+    sudo pacman -Syu --noconfirm
+    echo 'Install make'
+    sudo pacman -S --noconfirm make
+    echo 'Install ansible'
+    make install_ansible_arch
+    ;;
+  ubuntu)
+    echo 'Upgrade apt'
+    sudo apt-get -y upgrade
+    echo 'apt-get update'
+    sudo apt-get -y update
+    echo 'Install make'
+    sudo apt-get install -y make
+    echo 'Install ansible'
+    make install_ansible_ubuntu
+    ;;
+  *)
+    echo "Usage: $0 [arch|ubuntu]"
+    exit 1
+    ;;
+esac
+
 echo 'Set needed permissions for ansible'
 sudo chown -R $USER ~/.ansible/
 echo 'Install environment'

--- a/other/playbook.yml
+++ b/other/playbook.yml
@@ -1,9 +1,9 @@
 ---
 - hosts: all
   tasks: 
-    - name: Install needed packages
-      apt:
-        pkg:
+    - name: Install needed packages (Debian)
+      package:
+        name:
           - xclip
           - htop
           - graphviz
@@ -53,7 +53,46 @@
           - gimp
           - gnome-tweaks
       become: yes
-      become: true
+      when: ansible_pkg_mgr == 'apt'
+
+    - name: Install needed packages (Arch)
+      package:
+        name:
+          - xclip
+          - htop
+          - graphviz
+          - curl
+          - base-devel
+          - openssl
+          - readline
+          - zlib
+          - sqlite
+          - llvm
+          - xz
+          - tk
+          - automake
+          - libtool
+          - bison
+          - libffi
+          - lzma
+          - openvpn
+          - vlc
+          - postgresql
+          - gparted
+          - arduino
+          - ffmpeg
+          - net-tools
+          - libpqxx
+          - ruby
+          - redis
+          - cmake
+          - ncdu
+          - mumble
+          - imagemagick
+          - gimp
+          - gnome-tweaks
+      become: yes
+      when: ansible_pkg_mgr == 'pacman'
     # - copy:
     #     src: "../files/pg_hba.conf"
     #     dest: /etc/postgresql/14/main/pg_hba.conf

--- a/package_managers/app_image_launcher.yml
+++ b/package_managers/app_image_launcher.yml
@@ -1,15 +1,19 @@
 - hosts: all
   become_user: root
   tasks:
-    - apt:
-        pkg:
+    - package:
+        name:
           - software-properties-common
       become: true
+      when: ansible_pkg_mgr == 'apt'
     - command: add-apt-repository ppa:appimagelauncher-team/stable
       become: true
+      when: ansible_pkg_mgr == 'apt'
     - command: apt-get update
       become: true
-    - apt:
-        pkg:
+      when: ansible_pkg_mgr == 'apt'
+    - package:
+        name:
           - appimagelauncher
       become: true
+      when: ansible_pkg_mgr == 'apt'

--- a/package_managers/appimages.yml
+++ b/package_managers/appimages.yml
@@ -3,6 +3,7 @@
   tasks:
     - name: "FUSE2: Install"
       become: true
-      apt:
-        pkg:
+      package:
+        name:
           - libfuse2
+      when: ansible_pkg_mgr == 'apt'


### PR DESCRIPTION
## Summary
- Support both Ubuntu and Arch Linux in setup script via OS detection
- Provide separate Makefile targets for installing Ansible on Ubuntu and Arch
- Switch many Ansible playbooks from apt module to generic package module and guard apt-specific steps
- Document installation commands for Ubuntu and Arch

## Testing
- `bash -n main.sh`
- `sudo apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b5355528832a8632e9de7df6c478