### PR TITLE
Install Chrome only on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 install_environment:
-	ansible-playbook browser/google-chrome.yml -i local -vv -e curdir=$(CURDIR)
+	if [ "$(OS)" = "ubuntu" ]; then \
+		ansible-playbook browser/google-chrome.yml -i local -vv -e curdir=$(CURDIR); \
+	fi
 	ansible-galaxy install -p $(CURDIR)/roles azavea.postgresql --ignore-errors
 	ansible-galaxy install -p $(CURDIR)/roles geerlingguy.nodejs --ignore-errors
 	ansible-playbook devtools/git.yml -i local -vv

--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ It installs Ansible and use Ansible playbook to install other applications
 17. rvm*
 18. GIMP
 19. Ubuntu Tweaks
-20. Google Chrome
+20. Google Chrome (Ubuntu only)
 21. Rocket.Chat Desktop
 22. pyenv
 23. cmake

--- a/main.sh
+++ b/main.sh
@@ -40,7 +40,7 @@ esac
 echo 'Set needed permissions for ansible'
 sudo chown -R $USER ~/.ansible/
 echo 'Install environment'
-make install_environment && make update_vim && make update_bash
+OS=$OS make install_environment && make update_vim && make update_bash
 
 echo 'Add current user to docker group'
 sudo usermod -a -G docker $USER


### PR DESCRIPTION
## Summary
- install Google Chrome only when OS is Ubuntu
- document that Chrome is Ubuntu-only

## Testing
- `bash -n main.sh`
- `OS=ubuntu make -n install_environment | head -n 5`
- `OS=arch make -n install_environment | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68c6b8729658832a96ffbcc7897a3745