### PR TITLE
Rename Arch configuration to Omarchy and add monitor playbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,13 @@ install_environment:
 	ansible-playbook sec/ssh.yml -i local -vv
 	ansible-playbook devices/bluetooth.yml -i local -vv
 	ansible-playbook devices/lefthook.yml -i local -vv
+	ansible-playbook devices/monitor.yml -i local -vv
 	./sec/1password_cli.sh
 install_ansible_ubuntu:
 	sudo apt install -y software-properties-common
 	sudo apt install -y ansible
 	ansible-galaxy collection install community.general
-install_ansible_arch:
+install_ansible_omarchy:
 	sudo pacman -Syu --noconfirm ansible
 	ansible-galaxy collection install community.general
 update_neovim:

--- a/Readme.md
+++ b/Readme.md
@@ -8,15 +8,15 @@ Just run
 sudo apt-get install unzip && wget -O main.zip https://github.com/kalashnikovisme/dotfiles/archive/refs/heads/main.zip && unzip main.zip -d dotfiles && cd dotfiles/dotfiles-main && ./main.sh ubuntu && cd ~ && sudo rm -rf main.zip dotfiles
 ```
 
-### Arch Linux
+### Omarchy
 
 ```
-sudo pacman -Sy --noconfirm unzip wget && wget -O main.zip https://github.com/kalashnikovisme/dotfiles/archive/refs/heads/main.zip && unzip main.zip -d dotfiles && cd dotfiles/dotfiles-main && ./main.sh arch && cd ~ && sudo rm -rf main.zip dotfiles
+sudo pacman -Sy --noconfirm unzip wget && wget -O main.zip https://github.com/kalashnikovisme/dotfiles/archive/refs/heads/main.zip && unzip main.zip -d dotfiles && cd dotfiles/dotfiles-main && ./main.sh omarchy && cd ~ && sudo rm -rf main.zip dotfiles
 ```
 
 ## What is it?
 
-It's script to setup my own configuration for Ubuntu or Arch Linux
+It's script to setup my own configuration for Ubuntu or Omarchy
 
 It installs Ansible and use Ansible playbook to install other applications
 

--- a/content/obs.yml
+++ b/content/obs.yml
@@ -23,7 +23,7 @@
       become: true
       when: ansible_pkg_mgr == 'apt'
 
-    - name: Install obs (Arch)
+    - name: Install obs (Omarchy)
       package:
         name:
           - obs-studio

--- a/devices/monitor.yml
+++ b/devices/monitor.yml
@@ -1,0 +1,4 @@
+- hosts: all
+  tasks:
+    - name: Configure monitor
+      command: hyprctl keyword monitor eDP-1,1920x1080@60,0x0,1

--- a/devtools/docker.yml
+++ b/devtools/docker.yml
@@ -26,7 +26,7 @@
       become: true
       when: ansible_pkg_mgr == 'apt'
 
-    - name: "Docker: install (Arch)"
+    - name: "Docker: install (Omarchy)"
       package:
         name:
           - docker

--- a/devtools/vim.yml
+++ b/devtools/vim.yml
@@ -54,7 +54,7 @@
           - python3-pip
       when: ansible_pkg_mgr == 'apt'
 
-    - name: Install deoplete (Arch)
+    - name: Install deoplete (Omarchy)
       package:
         name:
           - python-pip
@@ -67,7 +67,7 @@
           - python3-msgpack
       when: ansible_pkg_mgr == 'apt'
 
-    - name: Install pynvim and msgpack (Arch)
+    - name: Install pynvim and msgpack (Omarchy)
       become: true
       package:
         name:

--- a/main.sh
+++ b/main.sh
@@ -6,20 +6,20 @@ OS="$1"
 
 if [ -z "$OS" ]; then
   if [ -f /etc/arch-release ]; then
-    OS="arch"
+    OS="omarchy"
   elif [ -f /etc/debian_version ]; then
     OS="ubuntu"
   fi
 fi
 
 case "$OS" in
-  arch)
+  omarchy)
     echo 'Upgrade pacman'
     sudo pacman -Syu --noconfirm
     echo 'Install make'
     sudo pacman -S --noconfirm make
     echo 'Install ansible'
-    make install_ansible_arch
+    make install_ansible_omarchy
     ;;
   ubuntu)
     echo 'Upgrade apt'
@@ -32,7 +32,7 @@ case "$OS" in
     make install_ansible_ubuntu
     ;;
   *)
-    echo "Usage: $0 [arch|ubuntu]"
+    echo "Usage: $0 [omarchy|ubuntu]"
     exit 1
     ;;
 esac

--- a/other/playbook.yml
+++ b/other/playbook.yml
@@ -55,7 +55,7 @@
       become: yes
       when: ansible_pkg_mgr == 'apt'
 
-    - name: Install needed packages (Arch)
+    - name: Install needed packages (Omarchy)
       package:
         name:
           - xclip


### PR DESCRIPTION
## Summary
- rename Arch Linux configuration to Omarchy across scripts and playbooks
- add `devices/monitor.yml` playbook with `hyprctl` monitor setup and run it during installation
- keep Makefile recipe indentation using tabs

## Testing
- `bash -n main.sh`
- `ansible-playbook --syntax-check devices/monitor.yml -i local` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 errors from repositories)*
- `sudo apt-get install -y ansible` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bc609da0832a93de6e255b86f4cd