### PR TITLE
Improve OS argument handling in main.sh

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -12,16 +12,20 @@ if [ -z "$OS" ]; then
   fi
 fi
 
+# Normalize the OS argument to avoid common copy/paste issues
+OS=$(echo "$OS" | tr '[:upper:]' '[:lower:]' | tr -d '\r\n')
+
 case "$OS" in
-  arch)
+  *arch*)
     echo 'Upgrade pacman'
     sudo pacman -Syu --noconfirm
     echo 'Install make'
     sudo pacman -S --noconfirm make
     echo 'Install ansible'
+    OS="arch"
     make install_ansible_arch
     ;;
-  ubuntu)
+  *ubuntu*|*debian*)
     echo 'Upgrade apt'
     sudo apt-get -y upgrade
     echo 'apt-get update'
@@ -29,6 +33,7 @@ case "$OS" in
     echo 'Install make'
     sudo apt-get install -y make
     echo 'Install ansible'
+    OS="ubuntu"
     make install_ansible_ubuntu
     ;;
   *)


### PR DESCRIPTION
## Summary
- Normalize OS argument to avoid case or newline issues
- Accept broader Arch and Debian/Ubuntu identifiers to reduce unexpected usage errors

## Testing
- `bash -n main.sh`
- `shellcheck main.sh` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bfbb37f8832ab9548b815dddc297