### PR TITLE
Install Docker only on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ install_environment:
 	ansible-playbook devtools/git.yml -i local -vv
 	ansible-playbook other/playbook.yml -i local -vv -e curdir=$(CURDIR)
 	ansible-playbook package_managers/snap.yml -i local -vvv -e curdir=$(CURDIR)
-	ansible-playbook devtools/docker.yml -i local -vv -e curdir=$(CURDIR)
+	if [ "$(OS)" = "ubuntu" ]; then \
+		ansible-playbook devtools/docker.yml -i local -vv -e curdir=$(CURDIR); \
+	fi
 	ansible-playbook languages/nodejs.yml -i local -vv -e curdir=$(CURDIR)
 	ansible-playbook content/audacity.yml -i local -vv -e curdir=$(CURDIR)
 	ansible-playbook content/obs.yml -i local -vv -e curdir=$(CURDIR)

--- a/devtools/docker.yml
+++ b/devtools/docker.yml
@@ -3,19 +3,19 @@
     docker_compose_version: "2.19.1"
   become_user: root
   tasks: 
-    - name: "Docker: Install prerequisites (Debian)"
+    - name: "Docker: Install prerequisites (Ubuntu)"
       package:
         name:
           - ca-certificates
           - gnupg
           - curl
       become: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_pkg_mgr == 'apt' and ansible_distribution == 'Ubuntu'
     - name: "Docker: prepare installation"
       command: sh ./docker/prepare_installation.sh
       become: true
-      when: ansible_pkg_mgr == 'apt'
-    - name: "Docker: install (Debian)"
+      when: ansible_pkg_mgr == 'apt' and ansible_distribution == 'Ubuntu'
+    - name: "Docker: install (Ubuntu)"
       package:
         name:
           - docker-ce
@@ -24,24 +24,19 @@
           - docker-buildx-plugin
           - docker-compose-plugin
       become: true
-      when: ansible_pkg_mgr == 'apt'
-
-    - name: "Docker: install (Omarchy)"
-      package:
-        name:
-          - docker
-          - docker-compose
-      become: true
-      when: ansible_pkg_mgr == 'pacman'
+      when: ansible_pkg_mgr == 'apt' and ansible_distribution == 'Ubuntu'
     - name: Post-install docker actions. Create docker group
       group:
         name: docker
         state: present
+      when: ansible_distribution == 'Ubuntu'
     - name: "Install docker-compose version: {{ docker_compose_version }}"
       command: 'curl -L "https://github.com/docker/compose/releases/download/v{{ docker_compose_version }}/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose'
       become: true
+      when: ansible_distribution == 'Ubuntu'
     - name: Add execute permissions
       become: true
       file:
         path: /usr/local/bin/docker-compose
         mode: +x
+      when: ansible_distribution == 'Ubuntu'

--- a/main.sh
+++ b/main.sh
@@ -46,10 +46,12 @@ sudo chown -R $USER ~/.ansible/
 echo 'Install environment'
 OS=$OS make install_environment && make update_vim && make update_bash
 
-echo 'Add current user to docker group'
-sudo usermod -a -G docker $USER
+if [ "$OS" = "ubuntu" ]; then
+  echo 'Add current user to docker group'
+  sudo usermod -a -G docker $USER
 
-echo 'Change docker owner to current user'
-sudo chown $USER:$USER /var/run/docker.sock
+  echo 'Change docker owner to current user'
+  sudo chown $USER:$USER /var/run/docker.sock
 
-echo 'NOW, LOG OUT AND LOG BACK TO APPLY DOCKER CHANGES'
+  echo 'NOW, LOG OUT AND LOG BACK TO APPLY DOCKER CHANGES'
+fi


### PR DESCRIPTION
## Summary
- run Docker setup only on Ubuntu hosts
- restrict Docker Ansible playbook to Ubuntu
- add Ubuntu check before Docker group adjustments

## Testing
- `bash -n main.sh`
- `bash -n devtools/docker/prepare_installation.sh`
- `make -n OS=ubuntu install_environment`
- `ansible-playbook --version` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c357ff50832a9724cf8c6162efda