### PR TITLE
Remove invalid lzma package from pacman install list

### DIFF
--- a/other/playbook.yml
+++ b/other/playbook.yml
@@ -74,7 +74,6 @@
           - libtool
           - bison
           - libffi
-          - lzma
           - openvpn
           - vlc
           - postgresql


### PR DESCRIPTION
## Summary
- fix pacman package list by removing invalid `lzma` entry

## Testing
- ⚠️ `ansible-playbook --syntax-check -i local other/playbook.yml` *(command not found)*
- ⚠️ `sudo apt-get update` *(403 repository error, unable to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c3eeaff4832a80d1155cd4e0125d