### PR TITLE
Add privilege escalation for pacman package installs

### DIFF
--- a/other/playbook.yml
+++ b/other/playbook.yml
@@ -90,6 +90,7 @@
           - imagemagick
           - gimp
           - gnome-tweaks
+      become: yes
       when: ansible_pkg_mgr == 'pacman'
     - command: "dpkg --add-architecture i386"
       become: true


### PR DESCRIPTION
## Summary
- ensure pacman-based package installation runs with root privileges

## Testing
- `ansible-playbook --syntax-check other/playbook.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c5204468832ab9ccc6d3d5c3b98f