### PR TITLE
Add privilege escalation for pacman package installs

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -15,6 +15,13 @@ fi
 # Normalize the OS argument to avoid common copy/paste issues
 OS=$(echo "$OS" | tr '[:upper:]' '[:lower:]' | tr -d '\r\n')
 
+# Collect sudo password for Ansible privilege escalation
+read -s -p "Enter sudo password: " ANSIBLE_BECOME_PASS
+echo
+echo "$ANSIBLE_BECOME_PASS" | sudo -S true
+export ANSIBLE_BECOME_PASS
+export ANSIBLE_BECOME_PASSWORD="$ANSIBLE_BECOME_PASS"
+
 case "$OS" in
   omarchy)
     echo 'Upgrade pacman'

--- a/other/playbook.yml
+++ b/other/playbook.yml
@@ -90,6 +90,7 @@
           - imagemagick
           - gimp
           - gnome-tweaks
+      become: yes
       when: ansible_pkg_mgr == 'pacman'
     - command: "dpkg --add-architecture i386"
       become: true


### PR DESCRIPTION
## Summary
- ensure pacman-based package installation runs with root privileges
- prompt for sudo password and export for Ansible so become succeeds

## Testing
- `bash -n main.sh`
- `ansible-playbook --syntax-check other/playbook.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c5204468832ab9ccc6d3d5c3b98f