### PR TITLE
Add Alacritty configuration for Omarchy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ install_environment:
 		ansible-playbook communication/discord.yml -i local -vv -e curdir=$(CURDIR); \
 		ansible-playbook content/spotify.yml -i local -vv -e curdir=$(CURDIR); \
 	fi
-	ansible-playbook style/fonts.yml -i local -vv -e curdir=$(CURDIR)
-	ansible-playbook package_managers/appimages.yml -i local -vv
+       ansible-playbook style/fonts.yml -i local -vv -e curdir=$(CURDIR)
+       ansible-playbook devtools/alacritty.yml -i local -vv
+       ansible-playbook package_managers/appimages.yml -i local -vv
 	ansible-playbook languages/ruby.yml -i local -vv
 	ansible-playbook languages/rust.yml -i local -vv
 	if [ "$(OS)" = "ubuntu" ]; then \

--- a/devtools/alacritty.yml
+++ b/devtools/alacritty.yml
@@ -1,0 +1,20 @@
+---
+- hosts: all
+  tasks:
+    - name: Install Alacritty (Omarchy)
+      become: true
+      package:
+        name: alacritty
+      when: ansible_pkg_mgr == 'pacman'
+
+    - name: Ensure Alacritty config directory exists
+      file:
+        path: ~/.config/alacritty
+        state: directory
+      when: ansible_pkg_mgr == 'pacman'
+
+    - name: Configure Alacritty
+      copy:
+        src: ../files/alacritty.yml
+        dest: ~/.config/alacritty/alacritty.yml
+      when: ansible_pkg_mgr == 'pacman'

--- a/files/alacritty.yml
+++ b/files/alacritty.yml
@@ -1,0 +1,4 @@
+font:
+  normal:
+    family: "Martian Mono"
+  size: 12.0


### PR DESCRIPTION
## Summary
- install and configure Alacritty on Omarchy
- apply Martian Mono font at size 12 in Alacritty config
- run playbook through Makefile

## Testing
- `ansible-playbook devtools/alacritty.yml -i local --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*
- `apt-get install -y ansible` *(fails: Unable to locate package ansible)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d8002adc832a9326b985d0cc7bcf