### PR TITLE
Set favorite apps only on Ubuntu

### DIFF
--- a/other/settings.yml
+++ b/other/settings.yml
@@ -3,6 +3,7 @@
   tasks:
     - name: Set Terminal as favorite app
       command: gsettings set org.gnome.shell favorite-apps "['org.gnome.Terminal.desktop', 'piavpn.desktop', 'sidekick-browser.desktop', 'telegramdesktop.desktop', 'gnome-control-center.desktop']"
+      when: ansible_distribution == 'Ubuntu'
       
     - name: Set dark theme
       command: gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'


### PR DESCRIPTION
## Summary
- limit GNOME favorite app configuration to Ubuntu hosts

## Testing
- `ansible-playbook other/settings.yml -i local --syntax-check` *(fails: ansible-playbook not installed)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d89f2730832ab25c5189726ce75d