### PR TITLE
Install lefthook as gem on Omarchy

### DIFF
--- a/devtools/lefthook.yml
+++ b/devtools/lefthook.yml
@@ -2,8 +2,16 @@
 - hosts: all
   become_user: root
   tasks:
-    - name: Install lefthook
+    - name: Install lefthook as a gem on Omarchy
+      community.general.gem:
+        name: lefthook
+        state: present
+      become: true
+      when: ansible_env.OS is defined and ansible_env.OS == "omarchy"
+
+    - name: Install lefthook via snap
       community.general.snap:
         name:
           - lefthook
       become: true
+      when: ansible_env.OS is not defined or ansible_env.OS != "omarchy"


### PR DESCRIPTION
## Summary
- install lefthook with RubyGems when environment variable `OS` is `omarchy`
- fallback to snap installation otherwise

## Testing
- `apt-get update` *(fails: The repository ... 403 Forbidden)*
- `pip install ansible` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e0313fe4832a8d78a4b5774a552c