### PR TITLE
Remove LazyVim before Neovim install on Omarchy

### DIFF
--- a/devtools/neovim.yml
+++ b/devtools/neovim.yml
@@ -1,6 +1,17 @@
 ---
 - hosts: all
   tasks:
+    - name: Remove LazyVim directories on Omarchy
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - ~/.config/nvim
+        - ~/.local/share/nvim
+        - ~/.local/state/nvim
+        - ~/.cache/nvim
+      when: ansible_env.OS is defined and ansible_env.OS == "omarchy"
+
     - name: Install Neovim
       become: yes
       package:


### PR DESCRIPTION
## Summary
- ensure Omarchy setups remove any existing LazyVim files before provisioning Neovim

## Testing
- `ansible-playbook devtools/neovim.yml -i local --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e4cffea8832aa8f63ad4625793e1