### PR TITLE
Add keyboard layout configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ install_environment:
 	ansible-playbook devtools/lefthook.yml -i local -vv
 	if [ "$(OS)" = "omarchy" ]; then \
 		ansible-playbook devices/monitor.yml -i local -vv; \
+		ansible-playbook devices/keyboard.yml -i local -vv; \
 	fi
 install_ansible_ubuntu:
 	sudo apt install -y software-properties-common

--- a/devices/keyboard.yml
+++ b/devices/keyboard.yml
@@ -1,0 +1,4 @@
+- hosts: all
+  tasks:
+    - name: Configure keyboard layout and remap keys
+      command: setxkbmap -layout us,ru -option ctrl:nocaps -option grp:lctrl_toggle


### PR DESCRIPTION
## Summary
- configure keyboard to remap CapsLock to Control and Left Ctrl to layout toggle
- ensure keyboard playbook runs on Omarchy

## Testing
- ⚠️ `ansible-playbook devices/keyboard.yml -i local --syntax-check` (ansible-playbook: command not found)
- ⚠️ `apt-get update` (403 repository errors while attempting to install Ansible)


------
https://chatgpt.com/codex/tasks/task_e_68c6e29548c8832abbb3a3fc6b329fc9