### PR TITLE
Alias vi and vim to nvim on Omarchy

### DIFF
--- a/tasks/alias.yml
+++ b/tasks/alias.yml
@@ -28,3 +28,13 @@
         - alias opengem='_() { cd $(rvm gemdir)/gems/$(gem list | grep -o "$1 (\([0-9]\.*\)*" | sed "s/ (/-/"); }; _'
         - alias dm="gp && gco main && gp && gpt && gco develop"
         - alias gce='git commit --allow-empty -m "Empty commit"'
+    - lineinfile:
+        dest: ~/.bashrc
+        state: present
+        line: "alias vi='nvim'"
+      when: ansible_env.OS is defined and ansible_env.OS == "omarchy"
+    - lineinfile:
+        dest: ~/.bashrc
+        state: present
+        line: "alias vim='nvim'"
+      when: ansible_env.OS is defined and ansible_env.OS == "omarchy"


### PR DESCRIPTION
## Summary
- Ensure users on Omarchy have `vi` and `vim` mapped to Neovim

## Testing
- `ansible-playbook tasks/alias.yml --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e494efe0832aab2c282c4ff00cb6