### PR TITLE
Ensure pynvim installed for Neovim on Omarchy

### DIFF
--- a/devtools/neovim.yml
+++ b/devtools/neovim.yml
@@ -18,6 +18,14 @@
         name: neovim
         state: present
 
+    - name: Ensure pynvim Python module is installed on Omarchy
+      pip:
+        name: pynvim
+        state: latest
+        executable: pip3
+        extra_args: --user
+      when: ansible_env.OS is defined and ansible_env.OS == "omarchy"
+
     - name: Ensure ~/.config/nvim directory exists
       file:
         path: ~/.config/nvim/


### PR DESCRIPTION
## Summary
- install pynvim via pip for omarchy to provide Neovim's Python3 provider

## Testing
- `ansible-playbook devtools/neovim.yml -i local --syntax-check` *(fails: command not found)*
- `pip install --user ansible` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e6e1b2c4832a8b37b1327a06f933