### PR TITLE
Configure Bash for Alacritty on Omarchy

### DIFF
--- a/devtools/alacritty.yml
+++ b/devtools/alacritty.yml
@@ -5,16 +5,16 @@
       become: true
       package:
         name: alacritty
-      when: ansible_pkg_mgr == 'pacman'
+      when: ansible_env.OS is defined and ansible_env.OS == "omarchy"
 
     - name: Ensure Alacritty config directory exists
       file:
         path: ~/.config/alacritty
         state: directory
-      when: ansible_pkg_mgr == 'pacman'
+      when: ansible_env.OS is defined and ansible_env.OS == "omarchy"
 
     - name: Configure Alacritty
       copy:
         src: ../files/alacritty.yml
         dest: ~/.config/alacritty/alacritty.yml
-      when: ansible_pkg_mgr == 'pacman'
+      when: ansible_env.OS is defined and ansible_env.OS == "omarchy"

--- a/files/alacritty.yml
+++ b/files/alacritty.yml
@@ -1,3 +1,7 @@
+shell:
+  program: /bin/bash
+  args:
+    - --login
 font:
   normal:
     family: "Martian Mono"


### PR DESCRIPTION
## Summary
- run Alacritty with Bash as the default shell
- restrict Alacritty setup to Omarchy hosts

## Testing
- `ansible-playbook devtools/alacritty.yml -i local --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e710662c832a899afef213e9bb71