### PR TITLE
Use dedicated bashrc without git prompt on omarchy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@ install_ansible_omarchy:
 update_neovim:
 	ansible-playbook devtools/neovim.yml -i local -vv
 update_bash:
-	cp -f files/bashrc ~/.bashrc
+	if [ "$(OS)" = "omarchy" ]; then \
+		cp -f files/bashrc_omarchy ~/.bashrc; \
+	else \
+		cp -f files/bashrc ~/.bashrc; \
+	fi
 	ansible-playbook tasks/alias.yml -i local -vv
 aquarium:
 	ansible-playbook devices/bluetooth.yml -i local -vv

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,7 @@ It installs Ansible and use Ansible playbook to install other applications
 * [vimrc](https://github.com/kalashnikovisme/dotfiles/blob/master/files/vimrc)
 * [gitconfig](https://github.com/kalashnikovisme/dotfiles/blob/master/files/.gitconfig)
 * [bashrc](https://github.com/kalashnikovisme/dotfiles/blob/master/files/bashrc)
+* [bashrc_omarchy](https://github.com/kalashnikovisme/dotfiles/blob/master/files/bashrc_omarchy)
 * [gitignore](https://github.com/kalashnikovisme/dotfiles/blob/master/files/gitignore)
 
 ## Actions
@@ -62,5 +63,5 @@ It installs Ansible and use Ansible playbook to install other applications
 
 ### Configurations
 
-* bashrc
+* bashrc / bashrc_omarchy
 * dpkg

--- a/files/bashrc_omarchy
+++ b/files/bashrc_omarchy
@@ -1,0 +1,148 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# don't put duplicate lines in the history. See bash(1) for more options
+# ... or force ignoredups and ignorespace
+HISTCONTROL=ignoredups:ignorespace
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Add an "alert" alias for long running commands.  Use like so:
+#   sleep 10; alert
+alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+    . /etc/bash_completion
+fi
+
+PATH=$PATH:$HOME/.rvm/bin # Add RVM to PATH for scripting
+PATH=$PATH:$HOME/go/bin # Add Go to PATH
+PATH=$PATH:$HOME/.pyenv/shims
+source ~/.rvm/scripts/rvm
+export PS1="\[\033[36m\]\w \[\033[34m\][\D{%H:%M}]: \[\033[37m\]"
+
+if [ -f /etc/bash_completion  ]; then
+  . /etc/bash_completion
+fi
+export GOPATH=$HOME/go
+export GOBIN=$GOPATH/bin
+PROMPT_COMMAND='echo -ne "\033]0;$(dirs)\007"'
+replace() {
+  find . -type f -exec sed -i "s/$1/$2/g" {} +
+}
+
+clip() {
+  file=$1
+  start_line=$2
+  end_line=$3
+
+  if [ -z "$start_line" ] || [ -z "$end_line" ]; then
+    echo "Error: Please provide the start and end line numbers."
+    echo "Usage: $0 <start_line> <end_line>"
+    exit 1
+  fi
+
+  tmp_file=$(mktemp)
+
+  sed -n "${start_line},${end_line}p" "$file" > "$tmp_file"
+
+  cat "$tmp_file" | xclip -selection clipboard
+
+  rm "$tmp_file"
+}
+
+# pyenv
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+if command -v pyenv 1>/dev/null 2>&1; then
+  eval "$(pyenv init -)"
+fi
+export DOCKER_BUILDKIT=1 # or configure in daemon.json
+export COMPOSE_DOCKER_CLI_BUILD=1


### PR DESCRIPTION
## Summary
- Provide a bashrc variant for Omarchy that omits __git_ps1 and sets a simple prompt
- Update Makefile to choose the git-less bashrc when OS=omarchy
- Document new bashrc option in README

## Testing
- `make update_bash OS=omarchy` *(fails: ansible-playbook: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f072e144832a9bcf26adf0652b8d