### PR TITLE
Add Hyprland monitor and input configs for Omarchy

### DIFF
--- a/devices/monitor.yml
+++ b/devices/monitor.yml
@@ -1,4 +1,19 @@
 - hosts: all
   tasks:
+    - name: Ensure Hyprland config directory exists
+      file:
+        path: ~/.config/hypr
+        state: directory
+
+    - name: Copy monitor configuration
+      copy:
+        src: ../files/omarchy/monitors.conf
+        dest: ~/.config/hypr/monitors.conf
+
+    - name: Copy input configuration
+      copy:
+        src: ../files/omarchy/input.conf
+        dest: ~/.config/hypr/input.conf
+
     - name: Configure monitor
       command: hyprctl keyword monitor eDP-1,1920x1080@60,0x0,1

--- a/files/omarchy/input.conf
+++ b/files/omarchy/input.conf
@@ -1,0 +1,30 @@
+input {
+  # Use multiple keyboard layouts and switch between them with Left Alt + Right Alt
+  # kb_layout = us,dk,eu
+  kb_layout = us,ru
+  kb_options = ctrl:nocaps,grp:lctrl_toggle # ,grp:alts_toggle
+
+  # Change speed of keyboard repeat
+  repeat_rate = 40
+  repeat_delay = 600
+
+  # Start with numlock on by default
+  numlock_by_default = true
+
+  # Increase sensitity for mouse/trackpack (default: 0)
+  # sensitivity = 0.35
+
+  touchpad {
+    # Use natural (inverse) scrolling
+    # natural_scroll = true
+
+    # Use two-finger clicks for right-click instead of lower-right corner
+    # clickfinger_behavior = true
+
+    # Control the speed of your scrolling
+    scroll_factor = 0.4
+  }
+}
+
+# Scroll faster in the terminal
+windowrule = scrolltouchpad 1.5, class:Alacritty

--- a/files/omarchy/monitors.conf
+++ b/files/omarchy/monitors.conf
@@ -1,0 +1,2 @@
+env = GDK_SCALE,2
+monitor = eDP-1,1920x1080@60,0x0,1


### PR DESCRIPTION
## Summary
- add `files/omarchy/monitors.conf` and `input.conf`
- copy Hyprland monitor and input configs during Omarchy setup

## Testing
- `ansible-playbook devices/monitor.yml -i local --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c73936e49c832aac23de6f96417e51