### PR TITLE
feat(nvim): map F2-F4 for omarchy

### DIFF
--- a/files/omarchy/init.lua
+++ b/files/omarchy/init.lua
@@ -1,0 +1,11 @@
+-- Neovim key mappings for Omarchy installation
+-- F2: write, F3: quit, F4: write and quit
+
+-- Map F2 to :w in normal and insert modes
+vim.keymap.set({'n', 'i'}, '<F2>', '<cmd>w<CR>', {silent = true})
+
+-- Map F3 to :q in normal and insert modes
+vim.keymap.set({'n', 'i'}, '<F3>', '<cmd>q<CR>', {silent = true})
+
+-- Map F4 to :wq in normal and insert modes
+vim.keymap.set({'n', 'i'}, '<F4>', '<cmd>wq<CR>', {silent = true})


### PR DESCRIPTION
## Summary
- add F2/F3/F4 key mappings for write/quit/write-quit in omarchy init.lua

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c824ed151c832a80053ea6611546a1