### PR TITLE
Disable line wrapping and enable relative numbers in Omarchy LazyVim setup

### DIFF
--- a/files/omarchy/init.lua
+++ b/files/omarchy/init.lua
@@ -1,6 +1,12 @@
 -- bootstrap lazy.nvim, LazyVim and your plugins
 require("config.lazy")
 
+-- Disable line wrapping by default
+vim.opt.wrap = false
+
+-- Enable relative line numbers like the init.vim configuration
+vim.opt.relativenumber = true
+
 -- Neovim key mappings for Omarchy installation
 -- F2: write, F3: quit, F4: write and quit
 


### PR DESCRIPTION
## Summary
- disable Vim line wrapping by default in the Omarchy LazyVim configuration so text no longer wraps automatically
- enable relative line numbers to match the init.vim configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c86365763c832aafc4ae1b49fb4837