### PR TITLE
Add LazyVim keymap overrides for Omarchy

### DIFF
--- a/files/omarchy/init.lua
+++ b/files/omarchy/init.lua
@@ -7,14 +7,3 @@ vim.opt.wrap = false
 -- Enable relative line numbers like the init.vim configuration
 vim.opt.relativenumber = true
 
--- Neovim key mappings for Omarchy installation
--- F2: write, F3: quit, F4: write and quit
-
--- Map F2 to :w in normal and insert modes
-vim.keymap.set({'n', 'i'}, '<F2>', '<cmd>w<CR>', {silent = true})
-
--- Map F3 to :q in normal and insert modes
-vim.keymap.set({'n', 'i'}, '<F3>', '<cmd>q<CR>', {silent = true})
-
--- Map F4 to :wq in normal and insert modes
-vim.keymap.set({'n', 'i'}, '<F4>', '<cmd>wq<CR>', {silent = true})

--- a/files/omarchy/lua/config/keymaps.lua
+++ b/files/omarchy/lua/config/keymaps.lua
@@ -1,0 +1,12 @@
+-- Keymaps are automatically loaded on the VeryLazy event
+-- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
+-- Add any additional keymaps here
+
+-- Free up the "s" key for custom usage in normal and visual modes
+vim.keymap.del("n", "s")
+vim.keymap.del("x", "s")
+
+-- Omarchy-specific function key mappings for saving and quitting
+vim.keymap.set({ "n", "i" }, "<F2>", "<cmd>w<CR>", { silent = true, desc = "Save file" })
+vim.keymap.set({ "n", "i" }, "<F3>", "<cmd>q<CR>", { silent = true, desc = "Quit" })
+vim.keymap.set({ "n", "i" }, "<F4>", "<cmd>wq<CR>", { silent = true, desc = "Save and quit" })


### PR DESCRIPTION
## Summary
- add a LazyVim keymap overrides file for the Omarchy installation
- move the F2/F3/F4 function key bindings into the keymap module and unmap LazyVim's default `s` key
- keep the Omarchy init.lua focused on editor options

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c86d0377f8832ab4fca8f28198b51f