### PR TITLE
Set Ghostty font size to 12

### DIFF
--- a/files/ghostty/config
+++ b/files/ghostty/config
@@ -1,2 +1,2 @@
 font-family = Martian Mono
-font-size = 22
+font-size = 12


### PR DESCRIPTION
### Motivation
- Adjust the Ghostty terminal configuration to use a smaller font size (12) to match the requested sizing change.

### Description
- Update `files/ghostty/config` to change `font-size` from `22` to `12` while keeping the existing `font-family` unchanged.

### Testing
- Verified the updated file content with `sed -n '1,50p' files/ghostty/config` and `nl -ba files/ghostty/config`, which show `font-size = 12`, and confirmed repository status with `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b97f81f4832aadb1d388b886a88e)